### PR TITLE
Update Metabase to v0.36.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM metabase/metabase:v0.24.2
+FROM metabase/metabase:v0.36.6


### PR DESCRIPTION
The current release in this repo is v0.24.x which apparently doesn't
support Postgres >= 10, even though we have somehow been running
Metabase against Postgres 11 in production for a while.

Slack thread: https://hypothes-is.slack.com/archives/CR3E3S7K8/p1600765256040600

Fixes https://github.com/hypothesis/playbook/issues/341