### PR TITLE
Metabase - Jenkinsfile update

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -10,14 +10,14 @@ node {
         img = buildApp(name: 'hypothesis/metabase')
     }
 
-    onlyOnMaster {
+    onlyOnMain {
         stage('release') {
             releaseApp(image: img)
         }
     }
 }
 
-onlyOnMaster {
+onlyOnMain {
     milestone()
     stage('qa deploy') {
         deployApp(image: img, app: 'metabase', env: 'qa', region: 'us-west-1')


### PR DESCRIPTION
Swapped the `onlyOnMaster` function for `onlyOnMain`. Change made
because the default branch for the metabase repository is now `main`.