### PR TITLE
Apply cookiecutter to just [re]deploy.yml

### DIFF
--- a/.github/workflows/redeploy.yml
+++ b/.github/workflows/redeploy.yml
@@ -1,55 +1,53 @@
-name: Deploy
+name: Redeploy
 concurrency:
   group: deploy
   cancel-in-progress: true
 on:
   workflow_dispatch:
-  push:
-    branches:
-      - main
+    inputs:
+      qa:
+        type: boolean
+        description: Redeploy QA
+      production:
+        type: boolean
+        description: Redeploy Production
+      production_canada:
+        type: boolean
+        description: Redeploy Production (Canada)
 jobs:
-  docker_hub:
-    name: Docker Hub
-    uses: hypothesis/workflows/.github/workflows/dockerhub.yml@main
-    with:
-      Application: ${{ github.event.repository.name }}
-    secrets: inherit
   qa:
     name: QA
-    needs: [docker_hub]
+    if: inputs.qa
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      operation: deploy
+      operation: redeploy
       github_environment_name: QA
       github_environment_url: https://qa-metabase.hypothes.is/
       aws_region: us-west-1
       elasticbeanstalk_application: metabase
       elasticbeanstalk_environment: qa
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
   production:
     name: Production
-    needs: [docker_hub, qa]
+    if: inputs.production
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      operation: deploy
+      operation: redeploy
       github_environment_name: Production
       github_environment_url: https://metabase.hypothes.is/
       aws_region: us-west-1
       elasticbeanstalk_application: metabase
       elasticbeanstalk_environment: prod
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit
   production_canada:
     name: Production (Canada)
-    needs: [docker_hub, qa]
+    if: inputs.production_canada
     uses: hypothesis/workflows/.github/workflows/deploy.yml@main
     with:
-      operation: deploy
+      operation: redeploy
       github_environment_name: Production (Canada)
       github_environment_url: https://metabase.ca.hypothes.is/
       aws_region: ca-central-1
       elasticbeanstalk_application: metabase
       elasticbeanstalk_environment: prod
-      docker_tag: ${{ needs.Docker_Hub.outputs.docker_tag }}
     secrets: inherit


### PR DESCRIPTION
Apply [the cookiecutter](https://github.com/hypothesis/cookiecutters) to just the GitHub Actions workflows `deploy.yml` and `redeploy.yml`.

This makes only formatting changes to `deploy.yml`, no functional changes.

This adds `redeploy.yml` which provides an easy way to redeploy the current version of the app from the repo's GitHub Actions tab.

See https://github.com/hypothesis/via/pull/829 for more details.
