### PR TITLE
Metabase 0.45.1 upgrade

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM metabase/metabase:v0.42.0
+FROM metabase/metabase:v0.45.1


### PR DESCRIPTION
0.42.0 > 0.45.1

This upgrade takes Metabase to the same version we are running for the Report environment.

We have run into problems with the service in Canada running v0.42.0. The service in the US is working as expected so this is a bit strange. Various steps to troubleshoot that included, redeploying the existing version and comparing the US and CA authentication configurations have not solved the problem.

We were expecting Google to make a change to their authentication services at the end of March, but I am wondering if something has change in Canada ahead of that date...

https://github.com/hypothesis/tech-ops/issues/42
https://github.com/hypothesis/playbook/issues/1041