### PR TITLE
Metabase 0.45.4.1 upgrade.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM metabase/metabase:v0.45.1
+FROM metabase/metabase:v0.45.4.1


### PR DESCRIPTION
Patch upgrade to address security concern:
https://github.com/metabase/metabase/releases/tag/v0.45.4.1

Part of the work towards:
- https://github.com/hypothesis/playbook/issues/1255